### PR TITLE
Rewrite count_lines to use the bytecount crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linecount"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Erik Clarke <erikclarke@fastmail.com>"]
 license = "GPL-3"
 description = "Quickly count lines in a file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ description = "Quickly count lines in a file"
 repository = "https://github.com/eclarke/linecount"
 
 [dependencies]
+bytecount = "0.4.0"
+
+[features]
+runtime-dispatch-simd = ["bytecount/runtime-dispatch-simd"]
+generic-simd = ["bytecount/generic-simd"]
 
 [[bin]]
 name = "lc"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 ## Description
-Provides a function `count_lines` to count the number of lines in a file. The speed is comparable to GNU wc.
+Provides a function `count_lines` to count the number of lines in a file. It's a few times faster than GNU wc.
+
+For best results build with `cargo build --release --features runtime-dispatch-simd`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 use std::io;
 use std::io::{BufRead, BufReader};
 
-const LF: u8 = '\n' as u8;
+const LF: u8 = b'\n';
 
 /// Counts lines in the source `handle`. 
 /// 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@ const LF: u8 = '\n' as u8;
 /// 
 /// # Examples
 /// ```
-/// use linecount::count_lines
-/// let lines: usize = count_lines(std::fs::File.open("foo.txt").unwrap()).unwrap()
+/// use linecount::count_lines;
+/// let lines: usize = count_lines(std::fs::File::open("Cargo.toml").unwrap()).unwrap();
 /// ```
 pub fn count_lines<R: io::Read>(handle: R) -> Result<usize, io::Error> {
     let mut reader = BufReader::new(handle);


### PR DESCRIPTION
I measure this as 6-7x faster than 0.1.0, and about 3x faster than GNU wc.

It also has constant memory use, rather than expanding a buffer arbitrarily to fit the longest line in a file.